### PR TITLE
Fix missing 0 in key derivation path example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ firmware version, or a firmware version that is supported by
 To authenticate with a connected Trezor device, pass the `--trezor ACCOUNT`
 option to the relevant command, where `ACCOUNT` is either:
 
-- the _full derivation path_ of the account, for example: `m/44h/60h/0h/123`
+- the _full derivation path_ of the account, for example: `m/44h/60h/0h/0/123`
 - the _index of the account_ at the default Trezor derivation prefix for
-  Ethereum coins `m/44h/60h/0h`, for example: `123`
+  Ethereum coins `m/44h/60h/0h/0`, for example: `123`
 
 The following two options are equivalent:
 
 - `--trezor 123`
-- `--trezor m/44h/60h/0h/123`
+- `--trezor m/44h/60h/0h/0/123`
 
 ### Local keyfile authentication
 


### PR DESCRIPTION
This fixes a missing "0/" in the README example of the key derivation path.

Indeed in the code -- as is in line with Ethereum standard -- the TREZOR_DEFAULT_PREFIX = "m/44h/60h/0h/0", and in https://github.com/clearmatics/simple-safe/blob/633036fbd08b74b786dc264f747b8e66ed50223b/src/simple_safe/auth.py#L167 the `index` gets appended _after_ that prefix.